### PR TITLE
fix: correct README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Content Intelligence - How To Intereact with our API - Postman Collections
+# AI Content Intelligence - How To Interact with our API - Postman Collections
 
 Welcome to our Content Intelligence (CI) Postman Collections Quickstart Guide! This guide provides you a quick way to get started with the CI API of Alphastream.
 


### PR DESCRIPTION
## Summary
- fix typo in main README header

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689478cc981c832db230ab8a7417e521